### PR TITLE
Optimize YieldStEthLever

### DIFF
--- a/contracts/YieldStEthLever.sol
+++ b/contracts/YieldStEthLever.sol
@@ -189,10 +189,8 @@ contract YieldStEthLever is IERC3156FlashBorrower {
         uint256 fee,
         bytes calldata data
     ) internal {
-        address thisAdd = address(this);
-
-        bytes12 vaultId = bytes12(data[1:13]);
         uint128 baseAmount = uint128(bytes16(data[13:29]));
+        bytes12 vaultId = bytes12(data[1:13]);
 
         // The total amount to invest. Equal to the base plus the borrowed minus the flash loan
         // fee.
@@ -201,7 +199,7 @@ contract YieldStEthLever is IERC3156FlashBorrower {
 
         // Get WETH
         pool.buyBase(
-            thisAdd,
+            address(this),
             uint128(pool.sellFYTokenPreview(netInvestAmount)),
             netInvestAmount
         );
@@ -212,7 +210,7 @@ contract YieldStEthLever is IERC3156FlashBorrower {
         stableSwap.exchange(
             0,
             1,
-            pool.base().balanceOf(thisAdd), // This value is different from base received
+            pool.base().balanceOf(address(this)), // This value is different from base received
             1,
             address(stEthConverter)
         );
@@ -222,7 +220,7 @@ contract YieldStEthLever is IERC3156FlashBorrower {
         // Deposit wstETH in the vault & borrow fyToken to payback
         ladle.pour(
             vaultId,
-            thisAdd,
+            address(this),
             int128(uint128(wrappedamount)),
             int128(uint128(borrowAmount))
         );

--- a/contracts/YieldStEthLever.sol
+++ b/contracts/YieldStEthLever.sol
@@ -136,12 +136,9 @@ contract YieldStEthLever is IERC3156FlashBorrower, Test {
         // TODO: What if these approvals fail by returning `false`? Is that even a case worth
         //  considering?
         fyToken.approve(address(ladle), type(uint256).max);
-        fyToken.approve(address(pool), type(uint256).max);
-        pool.base().approve(address(stableSwap), type(uint256).max);
-        wsteth.approve(address(stableSwap), type(uint256).max);
+        weth.approve(address(stableSwap), type(uint256).max);
         steth.approve(address(stableSwap), type(uint256).max);
         weth.approve(address(flashJoin2), type(uint256).max);
-        wsteth.approve(address(flashJoin), type(uint256).max);
         steth.approve(address(wsteth), type(uint256).max);
     }
 

--- a/contracts/YieldStEthLever.sol
+++ b/contracts/YieldStEthLever.sol
@@ -160,9 +160,9 @@ contract YieldStEthLever is IERC3156FlashBorrower, Test {
         uint128 borrowAmount,
         uint128 minCollateral,
         bytes6 seriesId
-    ) external returns (bytes12) {
+    ) external returns (bytes12 vaultId) {
         fyToken.safeTransferFrom(msg.sender, address(this), baseAmount);
-        (bytes12 vaultId, ) = ladle.build(seriesId, ilkId, 0);
+        (vaultId, ) = ladle.build(seriesId, ilkId, 0);
         // Since we know the sizes exactly, packing values in this way is more
         // efficient than using `abi.encode`.
         //
@@ -188,7 +188,6 @@ contract YieldStEthLever is IERC3156FlashBorrower, Test {
         // We put everything that we borrowed into the vault, so there can't be
         // any FYTokens left. Check:
         // assert(IERC20(address(fyToken)).balanceOf(address(this)) == 0);
-        return vaultId;
     }
 
     /// @notice Called by a flash lender, which can be `fyToken` or

--- a/contracts/YieldStEthLever.sol
+++ b/contracts/YieldStEthLever.sol
@@ -19,7 +19,6 @@ error SlippageFailure();
 
 interface WstEth is IERC20 {
     function wrap(uint256 _stETHAmount) external returns (uint256);
-
     function unwrap(uint256 _wstETHAmount) external returns (uint256);
 }
 
@@ -190,7 +189,7 @@ contract YieldStEthLever is IERC3156FlashBorrower, Test {
         } else if (status == 0x02) {
             doRepay(uint128(borrowAmount + fee), data);
         } else if (status == 0x03) {
-            doClose(borrowAmount, data);
+            doClose(data);
         }
         return FLASH_LOAN_RETURN;
     }
@@ -383,7 +382,7 @@ contract YieldStEthLever is IERC3156FlashBorrower, Test {
 
     /// @dev    - We have borrowed WstEth
     ///         - Sell it all for WEth and close position.
-    function doClose(uint256, bytes calldata data) internal {
+    function doClose(bytes calldata data) internal {
         bytes12 vaultId = bytes12(data[1:13]);
         uint128 ink = uint128(bytes16(data[13:29]));
         uint128 art = uint128(bytes16(data[29:45]));

--- a/contracts/YieldStEthLever.sol
+++ b/contracts/YieldStEthLever.sol
@@ -126,7 +126,7 @@ contract YieldStEthLever is IERC3156FlashBorrower {
 
     /// @notice Deploy this contract.
     /// @param giver_ The `Giver` contract to use.
-    /// @dev The contreact should never own anything in between transactions;
+    /// @dev The contract should never own anything in between transactions;
     ///     no tokens, no vaults. To save gas we give these tokens full
     ///     approval.
     constructor(Giver giver_) {
@@ -186,7 +186,7 @@ contract YieldStEthLever is IERC3156FlashBorrower {
         giver.give(vaultId, msg.sender);
         // We put everything that we borrowed into the vault, so there can't be
         // any FYTokens left. Check:
-        // assert(IERC20(address(fyToken)).balanceOf(address(this)) == 0);
+        require(IERC20(address(fyToken)).balanceOf(address(this)) == 0);
     }
 
     /// @notice Called by a flash lender, which can be `wstethJoin` or
@@ -344,7 +344,7 @@ contract YieldStEthLever is IERC3156FlashBorrower {
             // We have borrowed exactly enough for the debt and bought back
             // exactly enough for the loan + fee, so there is no balance of
             // FYToken left. Check:
-            // assert(IERC20(address(fyToken)).balanceOf(address(this)) == 0);
+            require(IERC20(address(fyToken)).balanceOf(address(this)) == 0);
         } else {
             // Repay:
             // Series is past maturity, borrow and move directly to collateral pool.

--- a/contracts/YieldStEthLever.sol
+++ b/contracts/YieldStEthLever.sol
@@ -114,6 +114,8 @@ contract YieldStEthLever is IERC3156FlashBorrower {
         giver = giver_;
         fyToken = fyToken_;
 
+        // TODO: What if these approvals fail by returning `false`? Is that even a case worth
+        //  considering?
         fyToken_.approve(address(pool), type(uint256).max);
         pool.base().approve(address(stableSwap), type(uint256).max);
         wsteth.approve(address(stableSwap), type(uint256).max);
@@ -293,6 +295,7 @@ contract YieldStEthLever is IERC3156FlashBorrower {
         (address borrower, bytes12 vaultId, uint128 ink, uint128 art) = abi
             .decode(data, (address, bytes12, uint128, uint128));
 
+        // TODO: Can this be in the constructor?
         fyToken.approve(address(ladle), art);
         ladle.pour(
             vaultId,

--- a/contracts/YieldStEthLever.sol
+++ b/contracts/YieldStEthLever.sol
@@ -88,41 +88,41 @@ contract YieldStEthLever is IERC3156FlashBorrower {
     using TransferHelper for WstEth;
 
     /// @notice By IERC3156, the flash loan should return this constant.
-    bytes32 internal constant FLASH_LOAN_RETURN =
+    bytes32 public constant FLASH_LOAN_RETURN =
         keccak256("ERC3156FlashBorrower.onFlashLoan");
 
     /// @notice WEth.
-    IERC20 constant weth = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    IERC20 public constant weth = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     /// @notice StEth, represents Ether stakes on Lido.
-    IERC20 constant steth = IERC20(0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84);
+    IERC20 public constant steth = IERC20(0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84);
     /// @notice WStEth, wrapped StEth, useful because StEth rebalances.
-    WstEth constant wsteth = WstEth(0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0);
+    WstEth public constant wsteth = WstEth(0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0);
 
     /// @notice The Yield Ladle, the primary entry point for most high-level
     ///     operations.
-    YieldLadle constant ladle =
+    YieldLadle public constant ladle =
         YieldLadle(0x6cB18fF2A33e981D1e38A663Ca056c0a5265066A);
     /// @notice The Yield Cauldron, handles debt and collateral balances.
-    ICauldron constant cauldron =
+    ICauldron public constant cauldron =
         ICauldron(0xc88191F8cb8e6D4a668B047c1C8503432c3Ca867);
     /// @notice Curve.fi token swapping contract between Ether and StETH.
-    IStableSwap constant stableSwap =
+    IStableSwap public constant stableSwap =
         IStableSwap(0x828b154032950C8ff7CF8085D841723Db2696056);
     /// @notice The ild ID for WStEth.
-    bytes6 constant ilkId = bytes6(0x303400000000);
+    bytes6 public constant ilkId = bytes6(0x303400000000);
     /// @notice The Yield Protocol Join containing WstEth.
-    FlashJoin constant wstethJoin =
+    FlashJoin public constant wstethJoin =
         FlashJoin(0x5364d336c2d2391717bD366b29B6F351842D7F82);
     /// @notice The Yield Protocol Join containing Weth.
-    FlashJoin constant wethJoin =
+    FlashJoin public constant wethJoin =
         FlashJoin(0x3bDb887Dc46ec0E964Df89fFE2980db0121f0fD0);
     /// @notice Ether Yield liquidity pool. Exchanges Weth with FYWeth.
-    IPool constant pool = IPool(0xc3348D8449d13C364479B1F114bcf5B73DFc0dc6);
+    IPool public constant pool = IPool(0xc3348D8449d13C364479B1F114bcf5B73DFc0dc6);
     /// @notice FyWeth, used to borrow based on Weth.
-    FYToken constant fyToken = FYToken(0x53358d088d835399F1E97D2a01d79fC925c7D999);
+    FYToken public constant fyToken = FYToken(0x53358d088d835399F1E97D2a01d79fC925c7D999);
     /// @notice The Giver contract can give vaults on behalf on a user who gave
     ///     permission.
-    Giver immutable giver;
+    Giver public immutable giver;
 
     /// @notice Deploy this contract.
     /// @param giver_ The `Giver` contract to use.

--- a/contracts/YieldStEthLever.sol
+++ b/contracts/YieldStEthLever.sol
@@ -208,12 +208,13 @@ contract YieldStEthLever is IERC3156FlashBorrower {
         uint256 fee,
         bytes calldata data
     ) external returns (bytes32) {
-        // Test that the flash loan was sent from the a contract and that this
-        // contract was the initiator.
-        if (
-            (msg.sender != address(fyToken) &&
-                msg.sender != address(wethJoin)) || initiator != address(this)
-        ) revert FlashLoanFailure();
+        // Test that the lender is either the fyToken contract or the Weth
+        // Join.
+        if (msg.sender != address(fyToken) && msg.sender != address(wethJoin))
+            revert FlashLoanFailure();
+        // We trust the lender, so now we can check that we were the initiator.
+        if (initiator != address(this))
+            revert FlashLoanFailure();
 
         // Decode the operation to execute and then call that function.
         bytes1 status = data[0];

--- a/contracts/YieldStEthLever.sol
+++ b/contracts/YieldStEthLever.sol
@@ -12,7 +12,6 @@ import "@yield-protocol/vault-v2/utils/Giver.sol";
 import "@yield-protocol/vault-v2/FlashJoin.sol";
 import "@yield-protocol/vault-v2/FYToken.sol";
 import "./interfaces/IStableSwap.sol";
-import "forge-std/Test.sol";
 
 error FlashLoanFailure();
 error SlippageFailure();
@@ -83,7 +82,7 @@ interface YieldLadle {
 ///     The way to do this in practice is by first borrowing the desired debt
 ///     through a flash loan and using this in additon to your own collateral.
 ///     The flash loan is repayed using funds borrowed using your collateral.
-contract YieldStEthLever is IERC3156FlashBorrower, Test {
+contract YieldStEthLever is IERC3156FlashBorrower {
     using TransferHelper for IERC20;
     using TransferHelper for FYToken;
     using TransferHelper for WstEth;

--- a/contracts/YieldStEthLever.sol
+++ b/contracts/YieldStEthLever.sol
@@ -75,6 +75,8 @@ contract YieldStEthLever is IERC3156FlashBorrower {
     using TransferHelper for IERC20;
     using TransferHelper for FyToken;
 
+    bytes32 internal constant FLASH_LOAN_RETURN = keccak256("ERC3156FlashBorrower.onFlashLoan");
+
     /// @notice The encoding of the operation to execute.
     enum OperationType {
         LEVER_UP,
@@ -129,8 +131,7 @@ contract YieldStEthLever is IERC3156FlashBorrower {
         uint128 borrowAmount,
         bytes6 seriesId
     ) external returns (bytes12) {
-        fyToken.safeTransferFrom(msg.sender, 
-            address(this), baseAmount);
+        fyToken.safeTransferFrom(msg.sender, address(this), baseAmount);
         (bytes12 vaultId, ) = ladle.build(seriesId, ilkId, 0);
         bool success = fyToken.flashLoan(
             this, // Loan Receiver
@@ -175,7 +176,7 @@ contract YieldStEthLever is IERC3156FlashBorrower {
         } else if (status == OperationType.CLOSE) {
             doClose(data2);
         }
-        return keccak256("ERC3156FlashBorrower.onFlashLoan");
+        return FLASH_LOAN_RETURN;
     }
 
     function leverUp(

--- a/contracts/interfaces/IStableSwap.sol
+++ b/contracts/interfaces/IStableSwap.sol
@@ -17,4 +17,7 @@ interface IStableSwap {
         uint256 min_dy,
         address receiver
     ) external returns (uint256);
+
+    /// @notice Get the amount of coin j one would receive for swapping _dx of coin i.
+    function get_dy(int128 i, int128 j, uint256 _dx) external view returns (uint256);
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,5 @@
 [default]
-src = 'src'
+src = 'contracts'
 out = 'out'
 libs = ['lib']
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,6 @@
 src = 'contracts'
 out = 'out'
 libs = ['lib']
-gas_reports = ['YieldStEthLever']
+gas_reports = ['contracts\YieldStEthLever.sol:YieldStEthLever']
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,5 +2,6 @@
 src = 'contracts'
 out = 'out'
 libs = ['lib']
+gas_reports = ['YieldStEthLever']
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/test/YieldStEthLever.t.sol
+++ b/test/YieldStEthLever.t.sol
@@ -38,16 +38,16 @@ contract YieldStEthLeverTest is Test {
     constructor() {
         protocol = new Protocol();
         fyToken = FYToken(0x53358d088d835399F1E97D2a01d79fC925c7D999);
-        flashJoin = FlashJoin(0x5364d336c2d2391717bD366b29B6F351842D7F82); //wsteth
+        flashJoin = FlashJoin(0x3bDb887Dc46ec0E964Df89fFE2980db0121f0fD0); // weth
         cauldron = ICauldron(0xc88191F8cb8e6D4a668B047c1C8503432c3Ca867);
+
         // Set the flash fee factor
         vm.prank(timeLock);
         fyToken.setFlashFeeFactor(1);
 
         vm.prank(timeLock);
         flashJoin.setFlashFeeFactor(1);
-        vm.label(address(fyToken), "FYToken");
-        vm.label(0x3bDb887Dc46ec0E964Df89fFE2980db0121f0fD0, "WETH JOIN");
+
         giver = new Giver(cauldron);
         // Orchestrate Giver
         AccessControl cauldronAccessControl = AccessControl(

--- a/test/YieldStEthLever.t.sol
+++ b/test/YieldStEthLever.t.sol
@@ -18,7 +18,6 @@ contract YieldStEthLeverTest is Test {
     address timeLock = 0x3b870db67a45611CF4723d44487EAF398fAc51E3;
     address fyTokenWhale = 0x1c15b746360BB8E792C6ED8cB83f272Ce1D170E0;
     YieldStEthLever lever;
-    FYToken fyToken;
     Protocol protocol;
     Giver giver;
 
@@ -26,6 +25,12 @@ contract YieldStEthLeverTest is Test {
     FlashJoin flashJoin;
     bytes6 seriesId = 0x303030370000;
     ICauldron cauldron;
+
+    
+    IERC20 constant weth = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    WstEth constant wsteth = WstEth(0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0);
+    IERC20 constant steth = IERC20(0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84);
+    FYToken immutable fyToken;
 
     IStableSwap constant stableSwap =
         IStableSwap(0x828b154032950C8ff7CF8085D841723Db2696056);
@@ -54,7 +59,7 @@ contract YieldStEthLeverTest is Test {
 
     function setUp() public {
         lever = new YieldStEthLever(
-            FyToken(0x53358d088d835399F1E97D2a01d79fC925c7D999),
+            FYToken(0x53358d088d835399F1E97D2a01d79fC925c7D999),
             giver
         );
 
@@ -92,9 +97,9 @@ contract YieldStEthLeverTest is Test {
         lever.unwind(
             balances.ink,
             balances.art,
+            minweth,
             vaultId,
-            seriesId,
-            minweth
+            seriesId
         );
         return vaultId;
     }
@@ -103,12 +108,24 @@ contract YieldStEthLeverTest is Test {
         bytes12 vaultId = leverUp(2e18, 6e18);
         DataTypes.Vault memory vault = cauldron.vaults(vaultId);
         assertEq(vault.owner, address(this));
+
+        // No tokens should be left in the contract
+        assertEq(weth.balanceOf(address(lever)), 0);
+        assertEq(wsteth.balanceOf(address(lever)), 0);
+        assertEq(steth.balanceOf(address(lever)), 0);
+        assertEq(fyToken.balanceOf(address(lever)), 0);
     }
 
     function testLever() public {
         bytes12 vaultId = leverUp(2e18, 5e18);
         DataTypes.Balances memory balances = cauldron.balances(vaultId);
         assertEq(balances.art, 5e18);
+
+        // No tokens should be left in the contract
+        assertEq(weth.balanceOf(address(lever)), 0);
+        assertEq(wsteth.balanceOf(address(lever)), 0);
+        assertEq(steth.balanceOf(address(lever)), 0);
+        assertEq(fyToken.balanceOf(address(lever)), 0);
     }
 
     function testLoanAndRepay() public {
@@ -118,6 +135,15 @@ contract YieldStEthLeverTest is Test {
         DataTypes.Balances memory balances = cauldron.balances(vaultId);
         assertEq(balances.art, 0);
         assertEq(balances.ink, 0);
+
+        // A very weak condition, but we should have at least some weth back.
+        assertGt(weth.balanceOf(address(this)), 0);
+
+        // No tokens should be left in the contract
+        assertEq(weth.balanceOf(address(lever)), 0);
+        assertEq(wsteth.balanceOf(address(lever)), 0);
+        assertEq(steth.balanceOf(address(lever)), 0);
+        assertEq(fyToken.balanceOf(address(lever)), 0);
     }
 
     function testLoanAndClose() public {
@@ -132,5 +158,14 @@ contract YieldStEthLeverTest is Test {
         DataTypes.Balances memory balances = cauldron.balances(vaultId);
         assertEq(balances.art, 0);
         assertEq(balances.ink, 0);
+
+        // A very weak condition, but we should have at least some weth back.
+        assertGt(weth.balanceOf(address(this)), 0);
+
+        // No tokens should be left in the contract
+        assertEq(weth.balanceOf(address(lever)), 0);
+        assertEq(wsteth.balanceOf(address(lever)), 0);
+        assertEq(steth.balanceOf(address(lever)), 0);
+        assertEq(fyToken.balanceOf(address(lever)), 0);
     }
 }

--- a/test/YieldStEthLever.t.sol
+++ b/test/YieldStEthLever.t.sol
@@ -50,7 +50,7 @@ contract YieldStEthLeverTest is Test {
 
     function setUp() public {
         lever = new YieldStEthLever(
-            IERC3156FlashLender(0x53358d088d835399F1E97D2a01d79fC925c7D999),
+            FyToken(0x53358d088d835399F1E97D2a01d79fC925c7D999),
             giver
         );
 
@@ -66,7 +66,7 @@ contract YieldStEthLeverTest is Test {
         giverAccessControl.grantRole(0x35775afb, address(lever));
     }
 
-    function leverUp(uint256 baseAmount, uint128 borrowAmount)
+    function leverUp(uint128 baseAmount, uint128 borrowAmount)
         public
         returns (bytes12 vaultId)
     {

--- a/test/YieldStEthLever.t.sol
+++ b/test/YieldStEthLever.t.sol
@@ -75,9 +75,7 @@ contract YieldStEthLeverTest is Test {
     }
 
     function unwind(bytes12 vaultId) public returns (bytes12) {
-        DataTypes.Balances memory balances = ICauldron(
-            0xc88191F8cb8e6D4a668B047c1C8503432c3Ca867
-        ).balances(vaultId);
+        DataTypes.Balances memory balances = cauldron.balances(vaultId);
         lever.unwind(
             vaultId,
             balances.art,
@@ -90,17 +88,14 @@ contract YieldStEthLeverTest is Test {
 
     function testVault() public {
         bytes12 vaultId = leverUp(2e18, 6e18);
-        DataTypes.Vault memory vault = ICauldron(
-            0xc88191F8cb8e6D4a668B047c1C8503432c3Ca867
-        ).vaults(vaultId);
+        DataTypes.Vault memory vault = cauldron.vaults(vaultId);
+        DataTypes.Balances memory balances = cauldron.balances(vaultId);
         assertEq(vault.owner, address(this));
     }
 
     function testLever() public {
         bytes12 vaultId = leverUp(2e18, 5e18);
-        DataTypes.Balances memory balances = ICauldron(
-            0xc88191F8cb8e6D4a668B047c1C8503432c3Ca867
-        ).balances(vaultId);
+        DataTypes.Balances memory balances = cauldron.balances(vaultId);
         assertEq(balances.art, 5e18);
     }
 
@@ -108,9 +103,7 @@ contract YieldStEthLeverTest is Test {
         bytes12 vaultId = leverUp(2e18, 4e18);
         unwind(vaultId);
 
-        DataTypes.Balances memory balances = ICauldron(
-            0xc88191F8cb8e6D4a668B047c1C8503432c3Ca867
-        ).balances(vaultId);
+        DataTypes.Balances memory balances = cauldron.balances(vaultId);
         assertEq(balances.art, 0);
         assertEq(balances.ink, 0);
     }
@@ -118,17 +111,13 @@ contract YieldStEthLeverTest is Test {
     function testLoanAndClose() public {
         bytes12 vaultId = leverUp(2e18, 4e18);
 
-        DataTypes.Series memory series_ = ICauldron(
-            0xc88191F8cb8e6D4a668B047c1C8503432c3Ca867
-        ).series(seriesId);
+        DataTypes.Series memory series_ = cauldron.series(seriesId);
 
         vm.warp(series_.maturity);
 
         unwind(vaultId);
 
-        DataTypes.Balances memory balances = ICauldron(
-            0xc88191F8cb8e6D4a668B047c1C8503432c3Ca867
-        ).balances(vaultId);
+        DataTypes.Balances memory balances = cauldron.balances(vaultId);
         assertEq(balances.art, 0);
         assertEq(balances.ink, 0);
     }

--- a/test/YieldStEthLever.t.sol
+++ b/test/YieldStEthLever.t.sol
@@ -77,10 +77,10 @@ contract YieldStEthLeverTest is Test {
     function unwind(bytes12 vaultId) public returns (bytes12) {
         DataTypes.Balances memory balances = cauldron.balances(vaultId);
         lever.unwind(
-            vaultId,
             balances.art,
             balances.ink,
             balances.art,
+            vaultId,
             seriesId
         );
         return vaultId;
@@ -89,7 +89,6 @@ contract YieldStEthLeverTest is Test {
     function testVault() public {
         bytes12 vaultId = leverUp(2e18, 6e18);
         DataTypes.Vault memory vault = cauldron.vaults(vaultId);
-        DataTypes.Balances memory balances = cauldron.balances(vaultId);
         assertEq(vault.owner, address(this));
     }
 

--- a/test/YieldStEthLever.t.sol
+++ b/test/YieldStEthLever.t.sol
@@ -26,7 +26,6 @@ contract YieldStEthLeverTest is Test {
     bytes6 seriesId = 0x303030370000;
     ICauldron cauldron;
 
-    
     IERC20 constant weth = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     WstEth constant wsteth = WstEth(0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0);
     IERC20 constant steth = IERC20(0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84);
@@ -58,10 +57,7 @@ contract YieldStEthLeverTest is Test {
     }
 
     function setUp() public {
-        lever = new YieldStEthLever(
-            FYToken(0x53358d088d835399F1E97D2a01d79fC925c7D999),
-            giver
-        );
+        lever = new YieldStEthLever(giver);
 
         //Label
         vm.label(address(lever), "YieldLever");
@@ -82,8 +78,15 @@ contract YieldStEthLeverTest is Test {
         fyToken.approve(address(lever), baseAmount);
         // Expect at least 80% of the value to end up as collateral
         uint256 wethAmount = pool.sellFYTokenPreview(baseAmount + borrowAmount);
-        uint128 minCollateral = uint128(stableSwap.get_dy(0, 1, wethAmount) * 80 / 100);
-        vaultId = lever.invest(baseAmount, borrowAmount, minCollateral, seriesId);
+        uint128 minCollateral = uint128(
+            (stableSwap.get_dy(0, 1, wethAmount) * 80) / 100
+        );
+        vaultId = lever.invest(
+            baseAmount,
+            borrowAmount,
+            minCollateral,
+            seriesId
+        );
     }
 
     function unwind(bytes12 vaultId) public returns (bytes12) {
@@ -92,15 +95,9 @@ contract YieldStEthLeverTest is Test {
         // Rough calculation of the minimal amount of weth that we want back.
         // In reality, the debt is not in weth but in fyWeth.
         uint256 collateralValueWeth = stableSwap.get_dy(1, 0, balances.ink);
-        uint256 minweth = (collateralValueWeth - balances.art) * 80 / 100;
+        uint256 minweth = ((collateralValueWeth - balances.art) * 80) / 100;
 
-        lever.unwind(
-            balances.ink,
-            balances.art,
-            minweth,
-            vaultId,
-            seriesId
-        );
+        lever.unwind(balances.ink, balances.art, minweth, vaultId, seriesId);
         return vaultId;
     }
 

--- a/test/YieldStEthLever.t.sol
+++ b/test/YieldStEthLever.t.sol
@@ -58,6 +58,7 @@ abstract contract ZeroState is Test {
 
     function setUp() public virtual {
         lever = new YieldStEthLever(giver);
+        lever.approveFyToken(seriesId);
 
         //Label
         vm.label(address(lever), "YieldLever");
@@ -147,6 +148,7 @@ contract ZeroStateTest is ZeroState {
             1e16,
             bytes.concat(
                 bytes1(0x01),
+                seriesId,
                 bytes12(0),
                 bytes16(0),
                 bytes16(0)


### PR DESCRIPTION
This PR does three things:
- Refactor: add some comments and simplify where possible
- Use `SafeTransfer`
- Optimize: gas improvements for levering, repaying and closing.

One thing that should potentially be fixed: if the approve methods fail by returning `false` it's a good idea to revert.

Slither also warns that constants (`ladle`, `cauldron`, ...) should be `CASE_WITH_UNDERSCORES`.