### PR TITLE
Introduce redeem

### DIFF
--- a/test/YieldStrategyLever.t.sol
+++ b/test/YieldStrategyLever.t.sol
@@ -114,6 +114,7 @@ abstract contract ZeroState is Test {
         returns (bytes12 vaultId)
     {
         vaultId = lever.invest(
+            YieldStrategyLever.Operation.BORROW,
             seriesId,
             strategyIlkId, // ilkId edai
             baseAmount,
@@ -165,6 +166,7 @@ contract UnwindTest is ZeroState {
     function testRepay() public {
         DataTypes.Balances memory balances = cauldron.balances(vaultId);
         lever.divest(
+            YieldStrategyLever.Operation.REPAY,
             vaultId,
             seriesId,
             strategyIlkId,
@@ -185,6 +187,7 @@ contract UnwindTest is ZeroState {
         vm.warp(series_.maturity);
         DataTypes.Balances memory balances = cauldron.balances(vaultId);
         lever.divest(
+            YieldStrategyLever.Operation.CLOSE,
             vaultId,
             seriesId,
             strategyIlkId,


### PR DESCRIPTION
These changes are a bit more contentious, so I created a new branch (I should have for the previous changes as well, really).

Made sure that assets always make it to the join or fyToken when repaying debt.
Introduced `_redeem`, as after maturity the fyToken need to be redeemed, and you can't use `burnForBase`